### PR TITLE
Remove Redirect Method for consistency across all the SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ If request was successful, you should consider saving the poll url sent from Pay
 
 ```php
 if($response->success()) {
-    // Redirect the user to Paynow with optional exit script boolean defaulting to false
-    $response->redirect(true);
 
-    // Or if you prefer more control, get the link to redirect the user to, then use it as you see fit
+    // Get the link to redirect the user to, then use it as you see fit
 	$link = $response->redirectLink();
 
 	// Get the poll url (used to check the status of a transaction). You might want to save this in your DB
@@ -161,10 +159,8 @@ $response = $paynow->send($payment);
 
 
 if($response->success()) {
-    // Redirect the user to Paynow with optional exit script boolean defaulting to false
-    $response->redirect(true);
 
-    // Or if you prefer more control, get the link to redirect the user to, then use it as you see fit
+    // Get the link to redirect the user to, then use it as you see fit
     $link = $response->redirectLink();
 
 	$pollUrl = $response->pollUrl();

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ and include the composer autoloader
 
 	// Do stuff
 ```
----
+
 ---
 
-# Or 
+---
+
+# Or
 
 Alternatively, if you do not have composer installed, [first download the library here](https://gitlab.com/paynow-developer-hub/Paynow-PHP-SDK/-/archive/master/Paynow-PHP-SDK-master.zip). And include the autoloader file included with the library
 
@@ -81,8 +83,8 @@ If request was successful, you should consider saving the poll url sent from Pay
 
 ```php
 if($response->success()) {
-    // Redirect the user to Paynow
-    $response->redirect();
+    // Redirect the user to Paynow with optional exit script boolean defaulting to false
+    $response->redirect(true);
 
     // Or if you prefer more control, get the link to redirect the user to, then use it as you see fit
 	$link = $response->redirectLink();
@@ -159,8 +161,8 @@ $response = $paynow->send($payment);
 
 
 if($response->success()) {
-    // Redirect the user to Paynow
-    $response->redirect();
+    // Redirect the user to Paynow with optional exit script boolean defaulting to false
+    $response->redirect(true);
 
     // Or if you prefer more control, get the link to redirect the user to, then use it as you see fit
     $link = $response->redirectLink();

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ When you're finally ready to send your payment to Paynow, you can use the `send`
 $response = $paynow->send($payment);
 ```
 
-The response from Paynow will b have some useful information like whether the request was successful or not. If it was, for example, it contains the url to redirect the user so they can make the payment. You can view the full list of data contained in the response in our wiki
+The response from Paynow will have some useful information like whether the request was successful or not. If it was, for example, it contains the url to redirect the user so they can make the payment. You can view the full list of data contained in the response in our wiki
 
 If request was successful, you should consider saving the poll url sent from Paynow in the database
 

--- a/src/Core/InitResponse.php
+++ b/src/Core/InitResponse.php
@@ -89,28 +89,6 @@ class InitResponse
     }
 
     /**
-     * Redirects the user to the url where they can make a payment
-     *
-     * @param bool $exit exit script after redirect
-     * 
-     * @return bool true if headers are not already sent and browser was redirected
-     */
-    public function redirect($exit = false)
-    {
-        $url = $this->redirectUrl();
-
-        if (!headers_sent() && !empty($url)) {
-            header("Location : " . $this->redirectUrl());
-            if ($exit) {
-                exit();
-            }
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
      * Returns the url the user should be taken to so they can make a payment
      *
      * @return bool|string

--- a/src/Core/InitResponse.php
+++ b/src/Core/InitResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Paynow\Core;
 
 use Paynow\Payments\InvalidIntegrationException;
@@ -50,19 +51,19 @@ class InitResponse
      */
     private function load()
     {
-        if(arr_has($this->data,'status')) {
+        if (arr_has($this->data, 'status')) {
             $this->status = strtolower($this->data['status']);
             $this->success = $this->status === Constants::RESPONSE_OK;
         }
-		
-        if(!$this->success()) {
-            if(arr_has($this->data, 'error')) {
+
+        if (!$this->success()) {
+            if (arr_has($this->data, 'error')) {
                 $this->fail(strtolower($this->data['error']));
             }
         }
     }
 
-    public function instructions() 
+    public function instructions()
     {
         return arr_has($this->data, 'instructions') ? $this->data['instructions'] : '';
     }
@@ -88,13 +89,35 @@ class InitResponse
     }
 
     /**
+     * Redirects the user to the url where they can make a payment
+     *
+     * @param bool $exit exit script after redirect
+     * 
+     * @return bool true if headers are not already sent and browser was redirected
+     */
+    public function redirect($exit = false)
+    {
+        $url = $this->redirectUrl();
+
+        if (!headers_sent() && !empty($url)) {
+            header("Location : " . $this->redirectUrl());
+            if ($exit) {
+                exit();
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Returns the url the user should be taken to so they can make a payment
      *
      * @return bool|string
      */
     public function redirectUrl()
     {
-        if(arr_has($this->data,'browserurl')) {
+        if (arr_has($this->data, 'browserurl')) {
             return $this->data['browserurl'];
         }
 


### PR DESCRIPTION
@iammerus In reference to this [comment](https://github.com/paynow/Paynow-PHP-SDK/pull/4#issuecomment-796850412), have removed the re-added `redirect()` method and updated the docs