### PR TITLE
Added helper functions to make it easier to check for status responses

### DIFF
--- a/src/Core/StatusResponse.php
+++ b/src/Core/StatusResponse.php
@@ -53,6 +53,81 @@ class StatusResponse
     }
 
     /**
+     * Check if transaction has been paid successfully.
+     * If so the transaction will be sitting in suspense waiting on the merchant to confirm delivery of the goods.
+     *
+     * @return mixed|string
+     */
+    public function awaitingDelivery()
+    {
+        return $this->status() === 'Awaiting Delivery' ? true : false;
+    }
+
+    /**
+     * Check if the user or merchant has acknowledged delivery of the goods but the funds are still sitting in
+     * suspense awaiting the 24 hour confirmation window to close.
+     *
+     * @return mixed|string
+     */
+    public function delivered()
+    {
+        return $this->status() === 'Delivered' ? true : false;
+    }
+
+    /**
+     * Check if transaction has been created in Paynow and an up stream system, the customer has been
+     * referred to that upstream system but has not yet made payment
+     *
+     * @return mixed|string
+     */
+    public function sent()
+    {
+        return $this->status() === 'sent' ? true : false;
+    }
+
+    /**
+     * Check if transaction has been created in Paynow, but has not yet been paid by the customer.
+     *
+     * @return mixed|string
+     */
+    public function created()
+    {
+        return $this->status() === 'created' ? true : false;
+    }
+
+    /**
+     * Check if transaction has been cancelled in Paynow.
+     * If so the transaction may not be resumed and needs to be recreated.
+     *
+     * @return mixed|string
+     */
+    public function cancelled()
+    {
+        return $this->status() === 'cancelled' ? true : false;
+    }
+
+    /**
+     * Check if transaction has been disputed by the Customer.
+     * If so funds are being held in suspense until the dispute has been resolved.
+     *
+     * @return mixed|string
+     */
+    public function disputed()
+    {
+        return $this->status() === 'disputed' ? true : false;
+    }
+
+    /**
+     * Check if funds were refunded back to the customer.
+     *
+     * @return mixed|string
+     */
+    public function refunded()
+    {
+        return $this->status() === 'refunded' ? true : false;
+    }
+
+    /**
      * Get the status of the transaction
      *
      * @return mixed|string


### PR DESCRIPTION
The documentation on https://developers.paynow.co.zw/docs/status_update.html#statuses contains 8 Status Responses but in the file src/Core/StatusResponse.php only 1 status is available for check. The proposed changes include the ability to check for the other 7 statuses.
